### PR TITLE
Enable Plausible auto capture features

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@vercel/functions": "^1.5.2",
     "@vercel/kv": "^1.0.1",
     "@vercel/speed-insights": "^1.2.0",
+    "@plausible-analytics/tracker": "^0.3.11",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "framer-motion": "^12.0.0-alpha.2",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { GoogleTagManager } from "@next/third-parties/google";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Analytics } from "@vercel/analytics/react";
+import { PlausibleAnalytics } from "@/components/plausible-analytics";
 
 // import { cn } from "@/lib/utils";
 
@@ -48,6 +49,7 @@ export default function RootLayout({
         </ThemeProvider>
         <SpeedInsights />
         <Analytics />
+        <PlausibleAnalytics />
       </body>
     </html>
   );

--- a/src/components/plausible-analytics.tsx
+++ b/src/components/plausible-analytics.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { init } from "@plausible-analytics/tracker";
+
+export function PlausibleAnalytics() {
+  useEffect(() => {
+    init({
+      domain: "bojin.co",
+      apiHost: "https://analytics.nszero.org",
+      autoPageviews: true,
+      outboundLinks: true,
+      fileDownloads: true,
+      formSubmissions: true,
+    });
+  }, []);
+
+  return null;
+}
+


### PR DESCRIPTION
## Summary
- enable Plausible's automatic pageview, outbound link, file download, and form submission tracking in the tracker bootstrapper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fee801d3448329bcacb0083a88d653