### PR TITLE
feat: added Plausible tracker

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@icons-pack/react-simple-icons": "^12.3.0",
         "@next/third-parties": "15.1.4",
+        "@plausible-analytics/tracker": "^0.4.3",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-navigation-menu": "^1.1.4",
         "@radix-ui/react-tooltip": "^1.1.8",
@@ -155,6 +156,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@plausible-analytics/tracker": ["@plausible-analytics/tracker@0.4.3", "", {}, "sha512-RKTgH5xu7Pa77VS4OEnS4woPhDxRgWLJlt9f6JhwgBC9ilknCfJIVEN2A1D8OR7hzgxMQF/hPyls9iN9ReAm3Q=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10" } }, "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw=="],
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@icons-pack/react-simple-icons": "^12.3.0",
     "@next/third-parties": "15.1.4",
+    "@plausible-analytics/tracker": "^0.4.3",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-tooltip": "^1.1.8",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Overpass, Old_Standard_TT, Overpass_Mono } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
+import { PlausibleTracker } from "@/components/plausible-tracker";
 import { GoogleTagManager } from "@next/third-parties/google";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Analytics } from "@vercel/analytics/react";
@@ -46,6 +47,7 @@ export default function RootLayout({
         >
           <main className="font-sans h-screen w-screen">{children}</main>
         </ThemeProvider>
+        <PlausibleTracker />
         <SpeedInsights />
         <Analytics />
       </body>

--- a/src/components/plausible-tracker.tsx
+++ b/src/components/plausible-tracker.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { init } from "@plausible-analytics/tracker";
+
+const domain = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN ?? "bojin.co";
+const endpoint = "https://analytics.nszero.org/api/event";
+let initialized = false;
+
+export function PlausibleTracker() {
+  useEffect(() => {
+    if (!initialized) {
+      init({
+        domain,
+        endpoint,
+        autoCapturePageviews: true,
+        outboundLinks: true,
+        fileDownloads: true,
+        formSubmissions: true,
+      });
+      initialized = true;
+    }
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- move the PlausibleTracker component call below the ThemeProvider to sit with the other analytics tooling

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ff15626df483299d652d3f589a0aff